### PR TITLE
Enable writing with acl

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2022-02-24
+### Added
+ - Ability to set ACL for put operations
+
 ## [0.0.1]
 ### Added
  - S3 client.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.install import install
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-VERSION = "0.0.1"
+VERSION = "0.0.2"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio_s3/clients/s3_client.py
+++ b/src/tentaclio_s3/clients/s3_client.py
@@ -29,7 +29,11 @@ class S3Client(base_client.BaseClient["S3Client"]):
     key_name: Optional[str]
 
     def __init__(
-        self, url: Union[urls.URL, str], aws_profile: str = None, conn_encrypt: bool = False
+        self,
+        url: Union[urls.URL, str],
+        aws_profile: str = None,
+        conn_encrypt: bool = False,
+        acl: str = None,
     ) -> None:
         """Create a new S3 client.
 
@@ -40,6 +44,7 @@ class S3Client(base_client.BaseClient["S3Client"]):
         """
         self.aws_profile = aws_profile
         self.conn_encrypt = conn_encrypt
+        self.acl = acl
         super().__init__(url)
 
         self.aws_access_key_id = self.url.username or None
@@ -106,7 +111,8 @@ class S3Client(base_client.BaseClient["S3Client"]):
         extra_args = {}
         if self.conn_encrypt:
             extra_args["ServerSideEncryption"] = "AES256"
-
+        if self.acl:
+            extra_args["ACL"] = self.acl
         self.conn.upload_fileobj(reader, s3_bucket, s3_key, ExtraArgs=extra_args)
 
     # Helpers:

--- a/tests/functional/s3/test_fs.py
+++ b/tests/functional/s3/test_fs.py
@@ -1,6 +1,7 @@
 import pytest
 import tentaclio as tio
-from tentaclio.clients.exceptions import S3Error
+
+from tentaclio_s3.clients.exceptions import S3Error
 
 
 def test_scandir(fixture_client, test_bucket):

--- a/tests/unit/clients/test_s3_client.py
+++ b/tests/unit/clients/test_s3_client.py
@@ -122,3 +122,20 @@ def test_build_url(url, expected, mocker):
 
     url = s3_client._build_url(client.bucket, "last_path/")
     assert url == expected
+
+
+@pytest.mark.parametrize(
+    "acl, expected",
+    (
+        ("bucket-owner-full-control", {"ACL": "bucket-owner-full-control"}),
+        ("public-read", {"ACL": "public-read"}),
+        (None, {}),
+    ),
+)
+def test_add_acl(mocker, mocked_conn, acl, expected):
+    url = "s3://bucket/path"
+    with s3_client.S3Client(url, acl=acl) as client:
+        client.conn.upload_fileobj = mocked_uploader = mocker.MagicMock()
+        reader = io.StringIO()
+        client.put(reader)
+        mocked_uploader.assert_called_with(reader, "bucket", "path", ExtraArgs=expected)


### PR DESCRIPTION
- Allows setting acl using:
```
with tio.open(url, "wb", acl="bucket-owner-full-control") as writer:
    df.to_parquet(writer)
```